### PR TITLE
Delete snapshots, add deregister image for backing AMIs

### DIFF
--- a/cmd/del/cmd.go
+++ b/cmd/del/cmd.go
@@ -1,0 +1,40 @@
+/*
+Copyright © 2022 James Harrington <james@harrington.net.au>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package del
+
+import (
+	"fmt"
+
+	"github.com/jharrington22/aws-resource/cmd/del/snapshots"
+	"github.com/spf13/cobra"
+)
+
+// DeleteCmd represents the list command
+var DelCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete AWS resources",
+	Long: `Delete AWS resources
+aws-resource delete snapshots`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("delete called")
+	},
+}
+
+func init() {
+
+	DelCmd.AddCommand(snapshots.Cmd)
+
+}

--- a/cmd/del/images/cmd.go
+++ b/cmd/del/images/cmd.go
@@ -1,0 +1,173 @@
+/*
+Copyright © 2022 James Harrington <james@harrington.net.au>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package images
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/jharrington22/aws-resource/pkg/arguments"
+	"github.com/jharrington22/aws-resource/pkg/aws"
+	logging "github.com/jharrington22/aws-resource/pkg/logging"
+	rprtr "github.com/jharrington22/aws-resource/pkg/reporter"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var (
+	imageId string
+	dryRun  bool
+)
+
+// Cmd represents the images command
+var Cmd = &cobra.Command{
+	Use:   "images",
+	Short: "Delete Images",
+	Long: `Delete images for all or a specific region
+
+aws-resource delete images`,
+	RunE: run,
+}
+
+func run(cmd *cobra.Command, args []string) (err error) {
+
+	reporter := rprtr.CreateReporterOrExit()
+	logging := logging.CreateLoggerOrExit(reporter)
+
+	reporter.Infof("Delete images")
+
+	awsClient, err := aws.NewClient().
+		Logger(logging).
+		Profile(arguments.Profile).
+		RoleArn(arguments.RoleArn).
+		Region(arguments.Region).
+		Build()
+
+	if err != nil {
+		reporter.Errorf("Unable to build AWS client")
+		return err
+	}
+
+	reporter.Infof("Dry run set to %s", strconv.FormatBool(dryRun))
+
+	regions, err := awsClient.DescribeRegions(&ec2.DescribeRegionsInput{})
+	if err != nil {
+		reporter.Errorf("Failed to describe regions")
+		return err
+	}
+
+	if imageId != "" {
+		reporter.Infof("Image id specified: %s", imageId)
+		_, err := deleteImageId(awsClient, imageId, dryRun)
+		if err != nil {
+			reporter.Errorf("Unable to delete image: %s", err)
+		}
+		reporter.Infof("Image %s deregistered", imageId)
+	}
+
+	if imageId == "" {
+		reporter.Infof("No image id specified")
+		err := deleteAllImages(reporter, logging, regions, dryRun)
+		if err != nil {
+			reporter.Errorf("Unable to delete image: %s", err)
+		}
+	}
+
+	return
+}
+
+func init() {
+	// Add global flags
+	flags := Cmd.Flags()
+	arguments.AddFlags(flags)
+	Cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Validate if delete would be successful")
+	Cmd.Flags().StringVarP(&imageId, "image-id", "i", "", "Delete specific image id")
+}
+
+func deleteImageId(client aws.Client, imageId string, dryRun bool) (*ec2.DeregisterImageOutput, error) {
+
+	input := &ec2.DeregisterImageInput{
+		DryRun:  &dryRun,
+		ImageId: &imageId,
+	}
+
+	output, err := client.DeregisterImage(input)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to deregister image: %s", err)
+	}
+
+	return output, err
+}
+
+func deleteAllImages(reporter *rprtr.Object, logging *logrus.Logger, regions *ec2.DescribeRegionsOutput, dryRun bool) error {
+
+	var allImages []*ec2.Image
+	for _, region := range regions.Regions {
+
+		regionName := *region.RegionName
+
+		awsClient, err := aws.NewClient().
+			Logger(logging).
+			Profile(arguments.Profile).
+			RoleArn(arguments.RoleArn).
+			Region(regionName).
+			Build()
+
+		if err != nil {
+			reporter.Errorf("Unable to build AWS client in %s", regionName)
+			os.Exit(1)
+		}
+
+		owner := "self"
+
+		input := &ec2.DescribeImagesInput{
+			Owners: []*string{&owner},
+		}
+
+		var images []*ec2.Image
+		output, err := awsClient.DescribeImages(input)
+		if err != nil {
+			reporter.Errorf("Unable to describe images %s", err)
+			return err
+		}
+
+		for _, image := range output.Images {
+			allImages = append(allImages, image)
+			images = append(images, image)
+			fmt.Printf("Deregistering image %s\n", *image.ImageId)
+			input := &ec2.DeregisterImageInput{
+				DryRun:  &dryRun,
+				ImageId: image.ImageId,
+			}
+
+			_, err := awsClient.DeregisterImage(input)
+			if err != nil {
+				return fmt.Errorf("Unable to deregister image: %s", err)
+			}
+
+			reporter.Infof("Image %s deregistered", imageId)
+		}
+
+		if len(images) > 0 {
+			reporter.Infof("Found %d images in %s", len(images), regionName)
+		}
+
+	}
+
+	return nil
+}

--- a/cmd/del/images/cmd.go
+++ b/cmd/del/images/cmd.go
@@ -149,7 +149,6 @@ func deleteAllImages(reporter *rprtr.Object, logging *logrus.Logger, regions *ec
 		for _, image := range output.Images {
 			allImages = append(allImages, image)
 			images = append(images, image)
-			fmt.Printf("Deregistering image %s\n", *image.ImageId)
 			input := &ec2.DeregisterImageInput{
 				DryRun:  &dryRun,
 				ImageId: image.ImageId,

--- a/cmd/del/snapshots/cmd.go
+++ b/cmd/del/snapshots/cmd.go
@@ -34,6 +34,7 @@ const (
 )
 
 var (
+	allRegions         bool
 	dryRun             bool
 	deleteBackingImage bool
 	snapshotId         string
@@ -56,13 +57,6 @@ func run(cmd *cobra.Command, args []string) (err error) {
 
 	reporter.Infof("Deleting ebs snapshots")
 
-	if arguments.Region == "" {
-		reporter.Errorf("Region required")
-		return err
-	}
-
-	reporter.Infof("Region: %s", arguments.Region)
-
 	awsClient, err := aws.NewClient().
 		Logger(logging).
 		Profile(arguments.Profile).
@@ -75,23 +69,56 @@ func run(cmd *cobra.Command, args []string) (err error) {
 		return err
 	}
 
-	owner := "self"
+	var snapshots []*ec2.Snapshot
+	if allRegions {
+		regions, err := awsClient.DescribeRegions(&ec2.DescribeRegionsInput{})
+		if err != nil {
+			reporter.Errorf("Failed to describe regions")
+			return err
+		}
 
-	input := &ec2.DescribeSnapshotsInput{
-		OwnerIds: []*string{&owner},
+		for _, region := range regions.Regions {
+			awsClient, err := aws.NewClient().
+				Logger(logging).
+				Profile(arguments.Profile).
+				RoleArn(arguments.RoleArn).
+				Region(*region.RegionName).
+				Build()
+
+			if err != nil {
+				reporter.Errorf("Unable to build AWS client for region: %s: %s", *region.RegionName, err)
+			}
+
+			ss, err := describeSnapshots(awsClient, reporter)
+			if err != nil {
+				reporter.Errorf("Unable to describe snapshots for region %s: err", *region.RegionName)
+				return err
+			}
+			snapshots = append(snapshots, ss...)
+		}
+
 	}
 
-	var snapshots []*ec2.Snapshot
-	err = awsClient.DescribeSnapshotsPages(input, func(output *ec2.DescribeSnapshotsOutput, lastPage bool) bool {
-		snapshots = append(snapshots, output.Snapshots...)
-		if output.NextToken == nil {
-			return false
+	if snapshotId != "" {
+		snapshot, err := awsClient.DescribeSnapshots(&ec2.DescribeSnapshotsInput{
+			SnapshotIds: []*string{&snapshotId},
+		})
+
+		if err != nil {
+			reporter.Errorf("Unable to describe snapshot id: %s", snapshotId)
+			return err
 		}
-		return true
-	})
-	if err != nil {
-		reporter.Errorf("Unable to describe snapshots %s", err)
-		return err
+		snapshots = append(snapshots, snapshot.Snapshots...)
+	}
+
+	// FIXME: Check if the default has been specified or remove the
+	// default of us-est-1 else this will always match
+	if (snapshotId == "" && arguments.Region != "") && !allRegions {
+		snapshots, err = describeSnapshots(awsClient, reporter)
+		if err != nil {
+			reporter.Errorf("Unable to describe snapshots for region %s", arguments.Region)
+			return err
+		}
 	}
 
 	if len(snapshots) == 0 {
@@ -104,62 +131,14 @@ func run(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	for _, snapshot := range snapshots {
-		input := &ec2.DeleteSnapshotInput{
-			DryRun:     &dryRun,
-			SnapshotId: snapshot.SnapshotId,
-		}
-
-		fmt.Println("here")
-
-		output, err := awsClient.DeleteSnapshot(input)
-		if aerr, ok := err.(awserr.Error); ok {
-			fmt.Println("in error")
-			switch aerr.Code() {
-			case InvalidSnapshotInUse:
-				reporter.Infof("Snapshot in use with backing AMI use --delete-backing-image to force delete: %s", aerr.Message())
-				amiId, err := parseInUseSnapshotImageIdErr(aerr.Message())
-				if err != nil {
-					reporter.Errorf("Parsing of snapshot (%s) in use error: %v", *snapshot.SnapshotId, err)
-					continue
-				}
-				reporter.Infof("AMI: %v", amiId)
-				if deleteBackingImage {
-					flags := images.Cmd.Flags()
-					reporter.Infof("Setting flags image id: %s dry-run: %t", amiId, dryRun)
-					err = flags.Set("image-id", amiId)
-					if err != nil {
-						reporter.Errorf("Unable to set image flag: %s", err)
-					}
-					err = flags.Set("dry-run", strconv.FormatBool(dryRun))
-					if err != nil {
-						reporter.Errorf("Unable to set dry run flag: %s", err)
-					}
-					err = images.Cmd.RunE(cmd, args)
-					if err != nil {
-						reporter.Errorf("Unable to list EC2 instances: %s", err)
-						return err
-					}
-					_, err = awsClient.DeleteSnapshot(input)
-					if err != nil {
-						return reporter.Errorf("Unable to delete snapshot: %s", err)
-					}
-				}
-			default:
-				fmt.Printf("error %s", err)
-
-			}
-		} else {
-			reporter.Errorf("Delete snapshot failed: %s", err)
-		}
-
-		fmt.Println("Finished")
-
-		if output != nil {
-			reporter.Infof("Snapshot %s deleted", *snapshot.SnapshotId)
+		err := deleteSnapshot(awsClient, cmd, reporter, snapshot, dryRun)
+		if err != nil {
+			fmt.Errorf("Unable to delete shapshot: %s", err)
+			return err
 		}
 	}
 
-	return
+	return nil
 
 }
 
@@ -168,6 +147,7 @@ func init() {
 	flags := Cmd.Flags()
 	arguments.AddFlags(flags)
 
+	Cmd.Flags().BoolVar(&allRegions, "all-regions", false, "Delete snapshots in all regions")
 	Cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Validate if delete would be successful")
 	Cmd.Flags().BoolVar(&deleteBackingImage, "delete-backing-image", false, "Delete snapshots backing AMI")
 }
@@ -179,4 +159,81 @@ func parseInUseSnapshotImageIdErr(errorMsg string) (string, error) {
 		return "", fmt.Errorf("Unexpected number of in use Image ID's for snapshot: %v", matches)
 	}
 	return matches[1], nil
+}
+
+func deleteSnapshot(awsClient aws.Client, cmd *cobra.Command, reporter *rprtr.Object, snapshot *ec2.Snapshot, dryRun bool) error {
+	input := &ec2.DeleteSnapshotInput{
+		DryRun:     &dryRun,
+		SnapshotId: snapshot.SnapshotId,
+	}
+
+	// Output from delete snapshot doesn't contain information we need
+	_, err := awsClient.DeleteSnapshot(input)
+	if aerr, ok := err.(awserr.Error); ok {
+		switch aerr.Code() {
+		case InvalidSnapshotInUse:
+			reporter.Infof("Snapshot in use with backing AMI use --delete-backing-image to force delete: %s", aerr.Message())
+			amiId, err := parseInUseSnapshotImageIdErr(aerr.Message())
+			if err != nil {
+				reporter.Errorf("Parsing of snapshot (%s) in use error: %v", *snapshot.SnapshotId, err)
+				return err
+			}
+			if deleteBackingImage {
+				flags := images.Cmd.Flags()
+				reporter.Infof("Setting flags image id: %s dry-run: %t", amiId, dryRun)
+				// Setting image ID for deletion
+				err = flags.Set("image-id", amiId)
+				if err != nil {
+					reporter.Errorf("Unable to set image flag: %s", err)
+				}
+				// Setting dry-run flag if specified
+				err = flags.Set("dry-run", strconv.FormatBool(dryRun))
+				if err != nil {
+					reporter.Errorf("Unable to set dry run flag: %s", err)
+				}
+				err = images.Cmd.RunE(cmd, []string{})
+				if err != nil {
+					reporter.Errorf("Unable to list EC2 instances: %s", err)
+					return err
+				}
+				_, err = awsClient.DeleteSnapshot(input)
+				if err != nil {
+					return reporter.Errorf("Unable to delete snapshot: %s", err)
+				}
+			}
+		// Don't return the error here just report that the deletion would have been
+		// successful without the dryRun flag set
+		case "DryRunOperation":
+			reporter.Infof("deletion of %s in %s", *snapshot.SnapshotId, aerr.Message())
+			return nil
+		default:
+			reporter.Errorf("error %s", err)
+			return err
+
+		}
+	} else {
+		reporter.Errorf("Delete snapshot failed: %s", err)
+		return err
+
+	}
+	return nil
+}
+
+func describeSnapshots(awsClient aws.Client, reporter *rprtr.Object) ([]*ec2.Snapshot, error) {
+	owner := "self"
+
+	input := &ec2.DescribeSnapshotsInput{
+		OwnerIds: []*string{&owner},
+	}
+
+	var snapshots []*ec2.Snapshot
+	err := awsClient.DescribeSnapshotsPages(input, func(output *ec2.DescribeSnapshotsOutput, lastPage bool) bool {
+		snapshots = append(snapshots, output.Snapshots...)
+		return !lastPage
+	})
+	if err != nil {
+		reporter.Errorf("Unable to describe snapshots %s", err)
+		return nil, err
+	}
+	return snapshots, err
 }

--- a/cmd/del/snapshots/cmd.go
+++ b/cmd/del/snapshots/cmd.go
@@ -1,0 +1,182 @@
+/*
+Copyright © 2022 James Harrington <james@harrington.net.au>
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package snapshots
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/jharrington22/aws-resource/cmd/del/images"
+	"github.com/jharrington22/aws-resource/pkg/arguments"
+	"github.com/jharrington22/aws-resource/pkg/aws"
+	logging "github.com/jharrington22/aws-resource/pkg/logging"
+	rprtr "github.com/jharrington22/aws-resource/pkg/reporter"
+	"github.com/spf13/cobra"
+)
+
+const (
+	InvalidSnapshotInUse = "InvalidSnapshot.InUse"
+)
+
+var (
+	dryRun             bool
+	deleteBackingImage bool
+	snapshotId         string
+)
+
+// Cmd represents the snapshots command
+var Cmd = &cobra.Command{
+	Use:   "snapshots",
+	Short: "Delete EBS snapshots",
+	Long: `Delete EBS snapshots for all or a specific region
+
+aws-resource delete snapshots --region <region name>`,
+	RunE: run,
+}
+
+func run(cmd *cobra.Command, args []string) (err error) {
+
+	reporter := rprtr.CreateReporterOrExit()
+	logging := logging.CreateLoggerOrExit(reporter)
+
+	reporter.Infof("Deleting ebs snapshots")
+
+	if arguments.Region == "" {
+		reporter.Errorf("Region required")
+		return err
+	}
+
+	reporter.Infof("Region: %s", arguments.Region)
+
+	awsClient, err := aws.NewClient().
+		Logger(logging).
+		Profile(arguments.Profile).
+		RoleArn(arguments.RoleArn).
+		Region(arguments.Region).
+		Build()
+
+	if err != nil {
+		reporter.Errorf("Unable to build AWS client")
+		return err
+	}
+
+	owner := "self"
+
+	input := &ec2.DescribeSnapshotsInput{
+		OwnerIds: []*string{&owner},
+	}
+
+	var snapshots []*ec2.Snapshot
+	err = awsClient.DescribeSnapshotsPages(input, func(output *ec2.DescribeSnapshotsOutput, lastPage bool) bool {
+		snapshots = append(snapshots, output.Snapshots...)
+		if output.NextToken == nil {
+			return false
+		}
+		return true
+	})
+	if err != nil {
+		reporter.Errorf("Unable to describe snapshots %s", err)
+		return err
+	}
+
+	if len(snapshots) == 0 {
+		reporter.Infof("No snapshots found in %s", arguments.Region)
+		return nil
+	}
+
+	if !dryRun {
+		reporter.Warnf("Dry run %t will delete resources", dryRun)
+	}
+
+	for _, snapshot := range snapshots {
+		input := &ec2.DeleteSnapshotInput{
+			DryRun:     &dryRun,
+			SnapshotId: snapshot.SnapshotId,
+		}
+
+		fmt.Println("here")
+
+		output, err := awsClient.DeleteSnapshot(input)
+		if aerr, ok := err.(awserr.Error); ok {
+			fmt.Println("in error")
+			switch aerr.Code() {
+			case InvalidSnapshotInUse:
+				reporter.Infof("Snapshot in use with backing AMI use --delete-backing-image to force delete: %s", aerr.Message())
+				amiId, err := parseInUseSnapshotImageIdErr(aerr.Message())
+				if err != nil {
+					reporter.Errorf("Parsing of snapshot (%s) in use error: %v", *snapshot.SnapshotId, err)
+					continue
+				}
+				reporter.Infof("AMI: %v", amiId)
+				if deleteBackingImage {
+					flags := images.Cmd.Flags()
+					reporter.Infof("Setting flags image id: %s dry-run: %t", amiId, dryRun)
+					err = flags.Set("image-id", amiId)
+					if err != nil {
+						reporter.Errorf("Unable to set image flag: %s", err)
+					}
+					err = flags.Set("dry-run", strconv.FormatBool(dryRun))
+					if err != nil {
+						reporter.Errorf("Unable to set dry run flag: %s", err)
+					}
+					err = images.Cmd.RunE(cmd, args)
+					if err != nil {
+						reporter.Errorf("Unable to list EC2 instances: %s", err)
+						return err
+					}
+					_, err = awsClient.DeleteSnapshot(input)
+					if err != nil {
+						return reporter.Errorf("Unable to delete snapshot: %s", err)
+					}
+				}
+			default:
+				fmt.Printf("error %s", err)
+
+			}
+		} else {
+			reporter.Errorf("Delete snapshot failed: %s", err)
+		}
+
+		fmt.Println("Finished")
+
+		if output != nil {
+			reporter.Infof("Snapshot %s deleted", *snapshot.SnapshotId)
+		}
+	}
+
+	return
+
+}
+
+func init() {
+	// Add global flags
+	flags := Cmd.Flags()
+	arguments.AddFlags(flags)
+
+	Cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Validate if delete would be successful")
+	Cmd.Flags().BoolVar(&deleteBackingImage, "delete-backing-image", false, "Delete snapshots backing AMI")
+}
+
+func parseInUseSnapshotImageIdErr(errorMsg string) (string, error) {
+	pattern := regexp.MustCompile(`.*(ami-[0-9a-z]{17}).*`)
+	matches := pattern.FindStringSubmatch(errorMsg)
+	if len(matches) != 2 {
+		return "", fmt.Errorf("Unexpected number of in use Image ID's for snapshot: %v", matches)
+	}
+	return matches[1], nil
+}

--- a/cmd/list/cmd.go
+++ b/cmd/list/cmd.go
@@ -22,6 +22,7 @@ import (
 	"github.com/jharrington22/aws-resource/cmd/list/ec2"
 	"github.com/jharrington22/aws-resource/cmd/list/elb"
 	"github.com/jharrington22/aws-resource/cmd/list/elbv2"
+	"github.com/jharrington22/aws-resource/cmd/list/images"
 	"github.com/jharrington22/aws-resource/cmd/list/route53"
 	"github.com/jharrington22/aws-resource/cmd/list/snapshots"
 	"github.com/jharrington22/aws-resource/cmd/list/volumes"
@@ -35,6 +36,9 @@ var ListCmd = &cobra.Command{
 	Long: `List AWS resources
 aws-resource list ec2
 aws-resource list elb
+aws-resource list elbv2
+aws-resource list images
+aws-resource list route53
 aws-resource list snapshots
 aws-resource list volumes`,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -48,6 +52,7 @@ func init() {
 	ListCmd.AddCommand(ec2.Cmd)
 	ListCmd.AddCommand(elb.Cmd)
 	ListCmd.AddCommand(elbv2.Cmd)
+	ListCmd.AddCommand(images.Cmd)
 	ListCmd.AddCommand(route53.Cmd)
 	ListCmd.AddCommand(snapshots.Cmd)
 	ListCmd.AddCommand(volumes.Cmd)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,7 @@ package cmd
 import (
 	"os"
 
+	"github.com/jharrington22/aws-resource/cmd/del"
 	"github.com/jharrington22/aws-resource/cmd/list"
 	"github.com/jharrington22/aws-resource/cmd/whoami"
 	"github.com/jharrington22/aws-resource/pkg/arguments"
@@ -45,6 +46,7 @@ func Execute() {
 }
 
 func init() {
+	RootCmd.AddCommand(del.DelCmd)
 	RootCmd.AddCommand(list.ListCmd)
 	RootCmd.AddCommand(whoami.WhoAmICmd)
 	// Here you will define your flags and configuration settings.

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -30,11 +30,15 @@ var (
 )
 
 type Client interface {
+	DeregisterImage(input *ec2.DeregisterImageInput) (*ec2.DeregisterImageOutput, error)
 	DescribeInstances(input *ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error)
+	DescribeImages(input *ec2.DescribeImagesInput) (*ec2.DescribeImagesOutput, error)
 	DescribeLoadBalancers(input *elb.DescribeLoadBalancersInput) (*elb.DescribeLoadBalancersOutput, error)
 	DescribeV2LoadBalancers(input *elbv2.DescribeLoadBalancersInput) (*elbv2.DescribeLoadBalancersOutput, error)
 	DescribeRegions(input *ec2.DescribeRegionsInput) (*ec2.DescribeRegionsOutput, error)
 	DescribeSnapshots(input *ec2.DescribeSnapshotsInput) (*ec2.DescribeSnapshotsOutput, error)
+	DescribeSnapshotsPages(input *ec2.DescribeSnapshotsInput, fn func(*ec2.DescribeSnapshotsOutput, bool) bool) error
+	DeleteSnapshot(input *ec2.DeleteSnapshotInput) (*ec2.DeleteSnapshotOutput, error)
 	DescribeVolumes(input *ec2.DescribeVolumesInput) (*ec2.DescribeVolumesOutput, error)
 	GetCallerIdentity(input *sts.GetCallerIdentityInput) (*sts.GetCallerIdentityOutput, error)
 	ListHostedZonesByName(input *route53.ListHostedZonesByNameInput) (*route53.ListHostedZonesByNameOutput, error)
@@ -261,15 +265,70 @@ func (c *awsClient) DescribeSnapshots(input *ec2.DescribeSnapshotsInput) (*ec2.D
 			default:
 				return nil, aerr
 			}
-		} else {
-			// Print the error, cast err to awserr.Error to get the Code and
-			// Message from an error.
-			return nil, err
 		}
 		return nil, fmt.Errorf("describe snpshots failed, %s", err)
 	}
 
 	return result, nil
+}
+
+func (c *awsClient) DescribeSnapshotsPages(input *ec2.DescribeSnapshotsInput, fn func(*ec2.DescribeSnapshotsOutput, bool) bool) error {
+	err := c.ec2Client.DescribeSnapshotsPages(input, fn)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			default:
+				return aerr
+			}
+		}
+		return fmt.Errorf("describe snapshots failed, %s", err)
+	}
+	return nil
+}
+
+func (c *awsClient) DeleteSnapshot(input *ec2.DeleteSnapshotInput) (output *ec2.DeleteSnapshotOutput, err error) {
+	output, err = c.ec2Client.DeleteSnapshot(input)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			default:
+				return nil, aerr
+			}
+		} else {
+			return nil, fmt.Errorf("describe snapshots failed, %s", err)
+		}
+	}
+	return output, nil
+}
+
+func (c *awsClient) DescribeImages(input *ec2.DescribeImagesInput) (output *ec2.DescribeImagesOutput, err error) {
+	output, err = c.ec2Client.DescribeImages(input)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			default:
+				return nil, aerr
+			}
+		} else {
+			return nil, fmt.Errorf("describe images failed, %s", err)
+		}
+	}
+	return output, nil
+}
+
+func (c *awsClient) DeregisterImage(input *ec2.DeregisterImageInput) (output *ec2.DeregisterImageOutput, err error) {
+	output, err = c.ec2Client.DeregisterImage(input)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			default:
+				return nil, aerr
+			}
+		} else {
+			return nil, fmt.Errorf("deregister images failed, %s", err)
+		}
+	}
+	return output, nil
 }
 
 func (c *awsClient) DescribeVolumes(input *ec2.DescribeVolumesInput) (*ec2.DescribeVolumesOutput, error) {


### PR DESCRIPTION
Delete snapshots, add the ability to deregister images so any AMI's backing a snapshot can be removed to delete the snapshot.