### PR TITLE
fix: aws-resource ignore in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-aws-resource
+./aws-resource


### PR DESCRIPTION
The term `aws-resource` matches on every element. This means, that
a binary in ./aws-resource will be ignored, but also a whole directory in ./cmd/aws-resource.
The commit fixes this via improving the regex and only matching the binary.