### PR TITLE
Fix missing main.go

### DIFF
--- a/cmd/aws-resource/main.go
+++ b/cmd/aws-resource/main.go
@@ -1,0 +1,22 @@
+/*
+Copyright © 2022 James Harrington <james@harrington.net.au>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package main
+
+import "github.com/jharrington22/aws-resource/cmd"
+
+func main() {
+	cmd.Execute()
+}


### PR DESCRIPTION
Adding main.go mistakenly missed because of gitignore. :facepalm: see #13 