### PR TITLE
Fix output for ec2 to be by line

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # aws-resource
-Tool to easily list AWS resources
+Tool to easily list and delete AWS resources
+
+Warning: All delete commands will delete resources with no warning, use the --dry-run command for any delete to see what resources would be deleted
+
+## General usage
+
+First use the aws-resource tool to list all resources within a given account
+
+```
+$ aws-resource list all
+```

--- a/cmd/list/ec2/cmd.go
+++ b/cmd/list/ec2/cmd.go
@@ -90,24 +90,26 @@ func run(cmd *cobra.Command, args []string) (err error) {
 		result, err := awsClient.DescribeInstances(input)
 
 		var runningInstanceList []*ec2.Instance
-		var detail []string
+		var detail [][]string
 		for _, r := range result.Reservations {
 			for _, i := range r.Instances {
+				var instanceDetail []string
 				if *i.State.Name == "running" {
 					runningInstanceList = append(runningInstanceList, i)
 					if instanceNames {
-						detail = append(detail, getInstanceName(i.Tags))
+						instanceDetail = append(instanceDetail, getInstanceName(i.Tags))
 					}
 					if launchTime {
-						detail = append(detail, i.LaunchTime.String())
+						instanceDetail = append(instanceDetail, i.LaunchTime.String())
 					}
 					if instanceType {
-						detail = append(detail, *i.InstanceType)
+						instanceDetail = append(instanceDetail, *i.InstanceType)
 					}
 					if imageId {
-						detail = append(detail, *i.ImageId)
+						instanceDetail = append(instanceDetail, *i.ImageId)
 					}
 				}
+				detail = append(detail, instanceDetail)
 			}
 		}
 		if len(runningInstanceList) > 0 {
@@ -115,7 +117,9 @@ func run(cmd *cobra.Command, args []string) (err error) {
 			reporter.Infof("Found %d running instances in %s", len(runningInstanceList), regionName)
 		}
 		if (instanceNames || launchTime || instanceType) && len(detail) > 0 {
-			reporter.Infof("%s", strings.Join(detail, ", "))
+			for _, d := range detail {
+				reporter.Infof("%s", strings.Join(d, ", "))
+			}
 		}
 	}
 	if !instancesFound {


### PR DESCRIPTION
Print output line by line when passing flags to `aws-resource list ec2`

Example:

```
aws-resource list ec2 --instance-names --profile james-dev --instance-type                                                                                                                                        
I: Listing ec2 instances                                                                                                                                     
I: Found 4 running instances in eu-central-1                                                                                                                 
I: jamesh-installer4-tes-4m4jw-master-0, m4.xlarge                                                                                                           
I: jamesh-installer4-tes-4m4jw-bootstrap, m4.large     
I: jamesh-installer4-tes-4m4jw-master-1, m4.xlarge 
```