### PR TITLE
Report attach and unattached volumes in list

### DIFF
--- a/cmd/list/volumes/cmd.go
+++ b/cmd/list/volumes/cmd.go
@@ -84,12 +84,25 @@ func run(cmd *cobra.Command, args []string) (err error) {
 		}
 
 		var volumes []*ec2.Volume
+		var attachedVolumes []*ec2.Volume
+		var unattachedVolumes []*ec2.Volume
 		for _, volume := range result.Volumes {
 			volumes = append(volumes, volume)
 			availableVolumes = append(availableVolumes, volume)
+			if len(volume.Attachments) > 0 {
+				attachedVolumes = append(attachedVolumes, volume)
+			} else {
+				unattachedVolumes = append(unattachedVolumes, volume)
+			}
 		}
 		if len(volumes) > 0 {
 			reporter.Infof("Found %d volumes in %s", len(volumes), regionName)
+		}
+		if len(volumes) > 0 {
+			reporter.Infof("%d attached volumes in %s", len(attachedVolumes), regionName)
+		}
+		if len(volumes) > 0 {
+			reporter.Infof("%d unattached volumes in %s", len(unattachedVolumes), regionName)
 		}
 	}
 	if len(availableVolumes) == 0 {


### PR DESCRIPTION
List will now show attached and unattached volumes

```
aws-resource list volumes
I: Listing ebs volumes
I: Found 3 volumes in ap-south-1     
I: 2 attached volumes in ap-south-1                                                                                                                           
I: 1 unattached volumes in ap-south-1
I: Found 2 volumes in eu-central-1   
I: 2 attached volumes in eu-central-1                                                                                                                         
I: 0 unattached volumes in eu-central-1
I: Found 738 volumes in us-east-1
I: 36 attached volumes in us-east-1    
I: 702 unattached volumes in us-east-1            
I: Found 1 volumes in us-east-2           
I: 0 attached volumes in us-east-2
I: 1 unattached volumes in us-east-2                                                                                                                          
I: Found 1 volumes in us-west-1                                               
I: 1 attached volumes in us-west-1
I: 0 unattached volumes in us-west-1  
```